### PR TITLE
Add support for mutual authentication via TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 scripts/license.lic
 .DS_Store
+.idea/

--- a/nexus3/pkg/client/client.go
+++ b/nexus3/pkg/client/client.go
@@ -16,7 +16,7 @@ const (
 	ContentTypeApplicationJSON = "application/json"
 	// ContentTypeTextPlain ...
 	ContentTypeTextPlain = "text/plain"
-	//
+	// BasePath ...
 	BasePath = "service/rest/"
 )
 
@@ -79,12 +79,12 @@ func (c *Client) ContentType() string {
 	return c.contentType
 }
 
-// ContentTypJSON configures the content type for future requests to be 'application/json'
+// ContentTypeJSON configures the content type for future requests to be 'application/json'
 func (c *Client) ContentTypeJSON() {
 	c.setContentType(ContentTypeApplicationJSON)
 }
 
-// ContentTypTestPlain configures the content typ for future requests to be 'test/plain'
+// ContentTypeTextPlain configures the content type for future requests to be 'test/plain'
 func (c *Client) ContentTypeTextPlain() {
 	c.setContentType(ContentTypeTextPlain)
 }

--- a/nexus3/pkg/client/config.go
+++ b/nexus3/pkg/client/config.go
@@ -2,9 +2,12 @@ package client
 
 // Config is the configuration structure used to instantiate the Nexus client
 type Config struct {
-	URL      string `json:"url"`
-	Username string `json:"username"`
-	Password string `json:"password"`
-	Insecure bool   `json:"insecure"`
-	Timeout  *int   `json:"timeout,omitempty"`
+	URL                   string  `json:"url"`
+	Username              string  `json:"username"`
+	Password              string  `json:"password"`
+	Insecure              bool    `json:"insecure"`
+	Timeout               *int    `json:"timeout,omitempty"`
+	ClientCertificatePath *string `json:"client_cert_path,omitempty"`
+	ClientKeyPath         *string `json:"client_key_path,omitempty"`
+	RootCAPath            *string `json:"root_ca_path,omitempty"`
 }


### PR DESCRIPTION

Prior to this change, there was no way to pass in a client certificate
if you had set up Nexus behind a load balancer with mutual auth
configured.

This change exposes some new configuration values that allow you to pass
in a path to a file on disk containing your client key/cert (which can
be in a single file) and optionally a Root CA.